### PR TITLE
Fix: Let mouse events pass through toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
             margin: 0 2px 0 0;
             box-sizing: border-box;
             align-items: flex-start;
+            pointer-events: all;
         }
 
         .xeokit-btn.disabled {


### PR DESCRIPTION
When scrolling in the viewer on the left or right of the toolbar it does not perform a zoom in the viewer. This PR fixes this and lets pointer events pass through.
![scroll-event-doesnt-pass](https://user-images.githubusercontent.com/327272/70811749-89273680-1dc6-11ea-94a3-dd9ba09413f1.gif)
